### PR TITLE
draco_bbox: Use cerr for error messages. And use more specific exit codes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -969,8 +969,9 @@ else ()
                  "${draco_src_root}/tools/draco_encoder.cc")
   target_link_libraries(draco_encoder PRIVATE draco)
 
+  find_package(fmt 5.2 REQUIRED)
   add_executable(draco_bbox "${draco_src_root}/tools/draco_bbox.cc")
-  target_link_libraries(draco_bbox PRIVATE dracodec draco)
+  target_link_libraries(draco_bbox PRIVATE dracodec draco fmt::fmt)
 
   if (ENABLE_TESTS)
     add_executable(draco_tests ${draco_test_sources})


### PR DESCRIPTION
A typical error with this application is the `NoOverlap` case, which usually is due to a mismatch of the coordinate systems of the point cloud (.ply) and the mesh (.drc).

By writing the error message to `std::cerr` and returning more specific exit-codes the user of this application (python code in bim-alignment-sintef or background-worker) can either throw an exception and use the `std::cerr` in the message as default, and create custom exceptions for specific exit-codes. For example, with `ExitCode::NoOverLap`, the python code could tell the user to check the manifest.json